### PR TITLE
fix/card

### DIFF
--- a/src/components/common/Card/Card.jsx
+++ b/src/components/common/Card/Card.jsx
@@ -1,7 +1,9 @@
-import React from 'react';
+import { React, useEffect, useState } from 'react';
+import classNames from 'classnames';
 import styles from './card.module.scss';
 import formatCardCreatedDate from '../../../utils/formatDataFunctions';
 import Profile from '../Profile/Profile';
+
 /*
 카드 컴포넌트
 props는 PostPage에서 
@@ -23,12 +25,25 @@ map으로 하나씩 내려줍니다
 function Card({ props }) {
   const { sender, profileImageURL, relationship, content, font, createdAt } =
     props;
+  const [trimmedContent, setTrimmedContent] = useState(content);
   const date = formatCardCreatedDate(createdAt);
 
   const handleModalOpen = e => {
     e.preventDefault();
     console.log('클릭하면 모달 창 띄우기');
   };
+  const textClass = classNames(styles.text);
+
+  useEffect(() => {
+    const div = document.querySelector(`.${textClass}`);
+    if (
+      content.length > 87 &&
+      (div.scrollHeight > div.clientHeight || div.scrollWidth > div.clientWidth)
+    ) {
+      // 텍스트가 div를 넘어갈 때 생략 부호 추가
+      setTrimmedContent(`${content.substring(0, 87)}...`);
+    }
+  }, []);
 
   return (
     <button
@@ -42,10 +57,9 @@ function Card({ props }) {
         relationship={relationship}
         font={font}
       />
-
       <hr className={styles.underline} />
       <p className={styles.text} style={{ fontFamily: font }}>
-        {content}
+        {trimmedContent}
       </p>
       <p className={styles.date} style={{ fontFamily: font }}>
         {date}

--- a/src/components/common/Card/card.module.scss
+++ b/src/components/common/Card/card.module.scss
@@ -23,10 +23,8 @@
     width: 21rem;
     height: 6.625rem;
     flex-shrink: 0;
-    overflow: hidden;
     text-align: start;
     color: var(--grayscale600, #4a4a4a);
-    text-overflow: ellipsis;
     white-space: nowrap;
     /* Font/18 Regular */
     font-size: 1.125rem;
@@ -34,6 +32,8 @@
     font-weight: 400;
     line-height: 1.75rem; /* 155.556% */
     letter-spacing: -0.0112rem;
+    white-space: normal;
+    word-wrap: break-word;
   }
   .date {
     color: var(--grayscale400, #999);


### PR DESCRIPTION
## ⚡️ What's Changing

- 어떤 부분을 구현했나요?
카드 컴포넌트안의 생략부호 추가

<br/>

## 🌈 How It Works

- 어떻게 작동하나요?
카드 컴포넌트 안의 내용이 넘치면 줄바꿈이 되고 마지막에 생략부호(...)도 추가했습니다. 
white-space: normal과 text-overflow: ellipsis; 를 같이 사용하면 생략 부호 적용이 안돼서 js 파일 안에서 생략부호를 넣어주었습니다. 
<br/>

## ✅ Screenshot

<img src="파일주소" width="50%" height="50%"/>

![스크린샷 2024-03-02 132545](https://github.com/Sprint-Part2-Team20/Rolling/assets/56138199/cca0f91c-4808-41c2-86ef-58d0dc424f2b)

<br/>

![스크린샷 2024-03-02 133546](https://github.com/Sprint-Part2-Team20/Rolling/assets/56138199/9b7d7f45-7ad7-4153-8f2f-213d229f09bc)

